### PR TITLE
Fix Gemini URL loading from environment file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# EmailJS (client — exposed via Vite)
+VITE_EMAILJS_SERVICE_ID=
+VITE_EMAILJS_PUBLIC_KEY=
+VITE_EMAILJS_TEMPLATE_ID=
+
+# PostHog (client)
+VITE_PUBLIC_POSTHOG_KEY=
+VITE_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+
+# Portfolio AI assistant (server only — never prefix with VITE_)
+# Get a key: https://aistudio.google.com/apikey
+GEMINI_API_KEY=
+# Gemini generateContent endpoint for your model, e.g.:
+# https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent
+GEMINI_URL=

--- a/README.md
+++ b/README.md
@@ -27,8 +27,26 @@ It showcases my skills, projects, and professional background as a Software Deve
 `cd portfolio`
 3. Install dependencies
 `npm install`
-4. Start the development server
+4. Copy environment variables and fill in your values:
+```bash
+cp .env.example .env
+```
+5. Start the development server
 `npm run dev`
+
+### Portfolio AI assistant (local dev)
+
+The chat widget calls `POST /api/assistant`. During `npm run dev`, the Vite plugin in `vite-plugin-assistant-api.js` handles that route and reads **server-only** variables from `.env` (not exposed to the browser):
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `GEMINI_API_KEY` | Yes | Google AI Studio API key |
+| `GEMINI_URL` | Yes | Full `generateContent` URL for your model |
+
+Example `GEMINI_URL`:
+`https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent`
+
+If either is missing, `/api/assistant` returns 503. After `npm run build`, `npm start` reads `GEMINI_*` from `.env` (or from variables you export in the shell).
 
 ## License
 This project is licensed under the [MIT License](./LICENSE).

--- a/server.mjs
+++ b/server.mjs
@@ -1,12 +1,13 @@
 #!/usr/bin/env node
 /**
  * Minimal production-style server: serves `dist/` and POST /api/assistant.
- * Usage after build: GEMINI_API_KEY=... node server.mjs
+ * Loads GEMINI_* from `.env` when not already set in the shell.
  * (Static hosts like GitHub Pages won't run this — use a Node host or split API elsewhere.)
  */
 
 import http from 'http'
 import fs from 'fs/promises'
+import { readFileSync } from 'fs'
 import path from 'path'
 import { fileURLToPath } from 'url'
 import {
@@ -17,7 +18,34 @@ import {
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const DIST = path.join(__dirname, 'dist')
 const PORT = Number(process.env.PORT) || 4173
-const apiKey = process.env.GEMINI_API_KEY
+
+/** Loads GEMINI_API_KEY and GEMINI_URL from project `.env` if missing from process.env. */
+function loadGeminiEnvFromDotenv() {
+  try {
+    const text = readFileSync(path.join(__dirname, '.env'), 'utf8')
+    for (const line of text.split('\n')) {
+      const trimmed = line.trim()
+      if (!trimmed || trimmed.startsWith('#')) continue
+      const eq = trimmed.indexOf('=')
+      if (eq === -1) continue
+      const key = trimmed.slice(0, eq).trim()
+      if (key !== 'GEMINI_API_KEY' && key !== 'GEMINI_URL') continue
+      if (process.env[key]) continue
+      let value = trimmed.slice(eq + 1).trim()
+      if (
+        (value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))
+      ) {
+        value = value.slice(1, -1)
+      }
+      process.env[key] = value
+    }
+  } catch {
+    // .env optional when vars are exported in the shell
+  }
+}
+
+loadGeminiEnvFromDotenv()
 
 const MIME = {
   '.html': 'text/html',
@@ -66,7 +94,10 @@ const server = http.createServer(async (req, res) => {
     const bodyText = Buffer.concat(chunks).toString('utf8')
 
     try {
-      const { statusCode, payload } = await handleAssistantPost(apiKey, bodyText)
+      const { statusCode, payload } = await handleAssistantPost(
+        process.env.GEMINI_API_KEY,
+        bodyText,
+      )
       res.writeHead(statusCode, { 'Content-Type': 'application/json' })
       res.end(JSON.stringify(payload))
     } catch {

--- a/server/gemini-assistant.mjs
+++ b/server/gemini-assistant.mjs
@@ -20,8 +20,6 @@ import { buildPortfolioSystemInstruction } from './portfolio-context.mjs'
 export const ASSISTANT_UNAVAILABLE_USER_MESSAGE =
   'Magret\'s AI assistant is temporarily unavailable. Please try again later.'
 
-const GEMINI_URL = process.env.GEMINI_URL
-
 const MAX_MESSAGES = 24
 /** Per-message cap so one turn cannot blow request size or tokens. */
 const MAX_MESSAGE_CHARS = 2000
@@ -53,7 +51,11 @@ function isRateOrCapacityIssue(status, apiError) {
  * Throws on failure — caller maps all throws to ASSISTANT_UNAVAILABLE_USER_MESSAGE for clients.
  */
 async function callGemini(apiKey, messages) {
-  const url = `${GEMINI_URL}?key=${encodeURIComponent(apiKey)}`
+  const geminiUrl = process.env.GEMINI_URL
+  if (!geminiUrl) {
+    throw new Error('missing_gemini_url')
+  }
+  const url = `${geminiUrl}?key=${encodeURIComponent(apiKey)}`
   const systemInstruction = buildPortfolioSystemInstruction()
 
   const body = {

--- a/src/components/Assistant/Assistant.jsx
+++ b/src/components/Assistant/Assistant.jsx
@@ -79,10 +79,15 @@ export default function Assistant() {
     setLoading(true)
 
     try {
+      const apiMessages = nextMessages.map((m) => ({
+        role: m.role === 'assistant' ? 'model' : m.role,
+        text: m.text,
+      }))
+
       const res = await fetch('/api/assistant', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ messages: nextMessages }),
+        body: JSON.stringify({ messages: apiMessages }),
       })
 
       const data = await safeReadJson(res)

--- a/vite-plugin-assistant-api.js
+++ b/vite-plugin-assistant-api.js
@@ -13,7 +13,8 @@ export function assistantApiPlugin() {
     name: 'assistant-api',
     configureServer(server) {
       const env = loadEnv(server.config.mode, process.cwd(), '')
-      const apiKey = env.GEMINI_API_KEY
+      if (env.GEMINI_API_KEY) process.env.GEMINI_API_KEY = env.GEMINI_API_KEY
+      if (env.GEMINI_URL) process.env.GEMINI_URL = env.GEMINI_URL
 
       server.middlewares.use(async (req, res, next) => {
         if (req.url !== '/api/assistant' || req.method !== 'POST') {
@@ -27,7 +28,10 @@ export function assistantApiPlugin() {
         const bodyText = Buffer.concat(chunks).toString('utf8')
 
         try {
-          const { statusCode, payload } = await handleAssistantPost(apiKey, bodyText)
+          const { statusCode, payload } = await handleAssistantPost(
+            process.env.GEMINI_API_KEY,
+            bodyText,
+          )
           res.statusCode = statusCode
           res.setHeader('Content-Type', 'application/json')
           res.end(JSON.stringify(payload))


### PR DESCRIPTION
This pull request improves environment variable management for the Portfolio AI assistant and enhances documentation for local development. The main changes ensure that required server-only environment variables (`GEMINI_API_KEY` and `GEMINI_URL`) are consistently loaded from `.env` files when not set in the shell, and that the assistant API is robust against missing configuration. The documentation is updated to guide developers through the setup process, and minor code adjustments improve the assistant's API compatibility.

**Environment variable loading and management:**

* Added logic in `server.mjs` to automatically load `GEMINI_API_KEY` and `GEMINI_URL` from `.env` if not already set in the environment, making local and production configuration more reliable.
* Updated `vite-plugin-assistant-api.js` to set `process.env.GEMINI_API_KEY` and `process.env.GEMINI_URL` from Vite's loaded environment, ensuring these variables are available during local development.

**Documentation and developer experience:**

* Updated `.env.example` to include all necessary variables for EmailJS, PostHog, and the Portfolio AI assistant, providing clear guidance for local setup.
* Enhanced `README.md` with explicit instructions to copy `.env.example` to `.env`, fill required values, and details about the AI assistant's environment variables and error handling.

**Assistant API robustness and compatibility:**

* Modified the assistant API to throw a clear error if `GEMINI_URL` is missing, and ensured all server code references the correct environment variables at runtime. 
* Updated the client-side assistant component to map the `assistant` role to `model` when sending messages to the backend, improving compatibility with the Gemini API.