### PR TITLE
Fix Gemini redirect issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,20 @@ The chat widget calls `POST /api/assistant`. During `npm run dev`, the Vite plug
 Example `GEMINI_URL`:
 `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent`
 
-If either is missing, `/api/assistant` returns 503. After `npm run build`, `npm start` reads `GEMINI_*` from `.env` (or from variables you export in the shell).
+If either is missing, `/api/assistant` returns 503.
+
+### Portfolio AI assistant (Netlify production)
+
+Production uses a Netlify serverless function (`netlify/functions/assistant.mjs`) that reuses `server/gemini-assistant.mjs`. `netlify.toml` rewrites `POST /api/assistant` to that function.
+
+In the Netlify UI (**Site configuration → Environment variables**), set the same server-only variables (do **not** use a `VITE_` prefix):
+
+- `GEMINI_API_KEY`
+- `GEMINI_URL`
+
+Redeploy after adding or changing env vars. The API key is never exposed to the browser.
+
+Optional: test the function locally with [Netlify CLI](https://docs.netlify.com/cli/get-started/) (`netlify dev`). For frontend-only work, `npm run dev` still uses the Vite plugin route.
 
 ## License
 This project is licensed under the [MIT License](./LICENSE).

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,16 @@
+[build]
+  command = "npm run build"
+  publish = "dist"
+
+[functions]
+  directory = "netlify/functions"
+  node_bundler = "esbuild"
+
+[[redirects]]
+  from = "/api/assistant"
+  to = "/.netlify/functions/assistant"
+  status = 200
+
 [[redirects]]
   from = "/*"
   to = "/index.html"

--- a/netlify/functions/assistant.mjs
+++ b/netlify/functions/assistant.mjs
@@ -1,0 +1,32 @@
+import {
+  handleAssistantPost,
+  ASSISTANT_UNAVAILABLE_USER_MESSAGE,
+} from '../../server/gemini-assistant.mjs'
+
+const JSON_HEADERS = { 'Content-Type': 'application/json' }
+
+export default async (request) => {
+  if (request.method !== 'POST') {
+    return new Response(JSON.stringify({ error: 'Method not allowed' }), {
+      status: 405,
+      headers: JSON_HEADERS,
+    })
+  }
+
+  try {
+    const bodyText = await request.text()
+    const { statusCode, payload } = await handleAssistantPost(
+      process.env.GEMINI_API_KEY,
+      bodyText,
+    )
+    return new Response(JSON.stringify(payload), {
+      status: statusCode,
+      headers: JSON_HEADERS,
+    })
+  } catch {
+    return new Response(
+      JSON.stringify({ error: ASSISTANT_UNAVAILABLE_USER_MESSAGE }),
+      { status: 503, headers: JSON_HEADERS },
+    )
+  }
+}

--- a/server/gemini-assistant.mjs
+++ b/server/gemini-assistant.mjs
@@ -2,8 +2,8 @@
  * Server-only Gemini helper: validates the client payload, calls the REST API,
  * and returns a plain object the HTTP layer can turn into JSON.
  *
- * Security: GEMINI_API_KEY is read only in Node (Vite plugin / server.mjs). It is
- * never sent to the browser or bundled into the client.
+ * Security: GEMINI_API_KEY is read only on the server (Vite dev plugin, Netlify
+ * function, or server.mjs). It is never sent to the browser or bundled into the client.
  *
  * Request flow (interview-friendly):
  * 1) Frontend POSTs chat messages to /api/assistant.


### PR DESCRIPTION
This pull request adds support for running the Portfolio AI assistant in Netlify production, using a serverless function to handle API requests securely. The main changes include introducing a Netlify serverless function for the assistant backend, updating deployment configuration, and clarifying documentation for production setup and environment variables.

**Netlify production support:**

* Added `netlify/functions/assistant.mjs`, a serverless function that handles `POST /api/assistant` requests in production by reusing the logic from `server/gemini-assistant.mjs`. It ensures the Gemini API key is kept server-side and never exposed to the browser.
* Updated `netlify.toml` to build the project, configure the functions directory, and rewrite `POST /api/assistant` to the Netlify function.

**Documentation updates:**

* Expanded the `README.md` with a new section explaining how the AI assistant works in Netlify production, how to set environment variables, and how to test locally with Netlify CLI.
* Clarified comments in `server/gemini-assistant.mjs` to note that `GEMINI_API_KEY` is only read server-side, including Netlify functions.